### PR TITLE
Increase integration order for segments

### DIFF
--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -9,8 +9,8 @@
 # `get_integration_points(element, 2)` third rule and so on. Rules should be
 # ordered so that picking next one integrates more accurately.
 integration_rule_mapping = (
-    :Seg2    => (:GLSEG1, :GLSEG2, :GLSEG3, :GLSEG4, :GLSEG5),
-    :Seg3    => (:GLSEG2, :GLSEG3, :GLSEG4, :GLSEG5),
+    :Seg2    => (:GLSEG2, :GLSEG3, :GLSEG4, :GLSEG5),
+    :Seg3    => (:GLSEG3, :GLSEG4, :GLSEG5),
     :NSeg    => (:GLSEG2, :GLSEG3, :GLSEG4, :GLSEG5),
     :Quad4   => (:GLQUAD4, :GLQUAD9, :GLQUAD16, :GLQUAD25),
     :Quad8   => (:GLQUAD9, :GLQUAD16, :GLQUAD25),

--- a/test/test_integrate.jl
+++ b/test/test_integrate.jl
@@ -8,8 +8,8 @@ using Base.Test
     element = Element(Seg2, [1, 2])
     ips1 = get_integration_points(element)
     ips2 = get_integration_points(element, 1)
-    @test length(ips1) == 1
-    @test length(ips2) == 2
+    @test length(ips1) == 2
+    @test length(ips2) == 3
     element = Element(Poi1, [1])
     ips3 = get_integration_points(element)
     @test length(ips3) == 1


### PR DESCRIPTION
They are cheap to integrate, use at least 2 point rule always.