### PR TITLE
New public function write_results!

### DIFF
--- a/src/FEMBase.jl
+++ b/src/FEMBase.jl
@@ -38,7 +38,8 @@ export LinearSystem, AbstractLinearSystemSolver, solve!
 
 include("analysis.jl")
 export AbstractAnalysis, Analysis, add_problems!, get_problems, run!,
-       AbstractResultsWriter, add_results_writer!, get_results_writers
+       AbstractResultsWriter, add_results_writer!, get_results_writers,
+       write_results!
 
 export FieldProblem, BoundaryProblem, Problem, Element, Assembly
 export Poi1, Seg2, Seg3, Tri3, Tri6, Tri7, Quad4, Quad8, Quad9,

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -37,3 +37,24 @@ end
 function run!{A<:AbstractAnalysis}(::Analysis{A})
     info("This is a placeholder function for running an analysis $A for a set of problems.")
 end
+
+function write_results!(::Analysis{A}, ::W) where {A<:AbstractAnalysis, W<:AbstractResultsWriter}
+    info("Writing the results of analysis $A is not supported by a results writer $W")
+    return nothing
+end
+
+function write_results!(analysis)
+    results_writers = get_results_writers(analysis)
+    if isempty(results_writers)
+        info("No result writers attached to the analysis $(analysis.name). ",
+             "In order to get results of the analysis stored to the disk, one ",
+             "must attach some results writer to the analysis using ",
+             "add_results_writer!, e.g. xdmf_writer = Xdmf(\"results\"); ",
+             "add_results_writer!(analysis, xdmf_writer)")
+        return nothing
+    end
+    for results_writer in results_writers
+        write_results!(analysis, results_writer)
+    end
+    return nothing
+end


### PR DESCRIPTION
`write_results!(analysis, writer)` is a function which is used to implement new results writers for some analysis. Usage example in pseudo-level

```julia
type XdmfWriter <: AbstractResultsWriter
    # stuff
end

type Dynamics <: AbstractAnalysis
    # stuff
end

function FEMBase.write_results!(analysis::Dynamics, writer::XdmfWriter)
    # fid = open(writer.filename)
    # for problem in get_problems(analysis)
    #     field = problem("displacement", analysis.time)
    #     write(fid, field)
    # end
    return nothing!
end
```