### PR TITLE
Fix deprecation warnings for Julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 language: julia
+
 os:
     - linux
+
 julia:
-    - 0.6
     - 0.7
+    - 1.0
     - nightly
+
 matrix:
     allow_failures:
-        - julia: 0.7
+        - julia: 1.0
         - julia: nightly
+
 before_script:
     - julia --color=yes -e 'Pkg.clone("https://github.com/JuliaFEM/PkgTestSuite.jl.git")'
     - julia --color=yes -e 'using PkgTestSuite; init()'
+
 script:
     - julia --color=yes -e 'using PkgTestSuite; test()'
+
 after_success:
     - julia --color=yes -e 'using PkgTestSuite; deploy()'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 FEMBasis
 FEMQuad
 TimerOutputs

--- a/src/FEMBase.jl
+++ b/src/FEMBase.jl
@@ -3,13 +3,15 @@
 
 module FEMBase
 
+using LinearAlgebra
+
 macro lintpragma(s)
 end
 
 import Base: getindex, setindex!, convert, length, size, isapprox,
-             similar, start, first, next, done, last, endof, vec,
+             start, first, next, done, last, endof, vec,
              ==, +, -, *, /, haskey, copy, push!, isempty, empty!,
-             append!, sparse, full, read
+             append!, read
 
 using TimerOutputs
 export @timeit, print_timer
@@ -57,7 +59,7 @@ export is_field_problem, is_boundary_problem, get_elements,
        eval_basis!, get_basis, get_dbasis, grad!,
        assemble_mass_matrix!, get_local_coordinates, inside,
        get_element_type, filter_by_element_type, get_element_id,
-       optimize!, resize_sparse, resize_sparsevec
+       resize_sparse, resize_sparsevec
 
 include("test.jl")
 

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -35,22 +35,22 @@ function get_results_writers(analysis::Analysis)
 end
 
 function run!(::Analysis{A}) where A<:AbstractAnalysis
-    info("This is a placeholder function for running an analysis $A for a set of problems.")
+    @info("This is a placeholder function for running an analysis $A for a set of problems.")
 end
 
 function write_results!(::Analysis{A}, ::W) where {A<:AbstractAnalysis, W<:AbstractResultsWriter}
-    info("Writing the results of analysis $A is not supported by a results writer $W")
+    @info("Writing the results of analysis $A is not supported by a results writer $W")
     return nothing
 end
 
 function write_results!(analysis)
     results_writers = get_results_writers(analysis)
     if isempty(results_writers)
-        info("No result writers attached to the analysis $(analysis.name). ",
-             "In order to get results of the analysis stored to the disk, one ",
-             "must attach some results writer to the analysis using ",
-             "add_results_writer!, e.g. xdmf_writer = Xdmf(\"results\"); ",
-             "add_results_writer!(analysis, xdmf_writer)")
+        @info("No result writers attached to the analysis $(analysis.name). " *
+              "In order to get results of the analysis stored to the disk, one " *
+              "must attach some results writer to the analysis using " *
+              "add_results_writer!, e.g. xdmf_writer = Xdmf(\"results\"); " *
+              "add_results_writer!(analysis, xdmf_writer)")
         return nothing
     end
     for results_writer in results_writers

--- a/src/elements_lagrange.jl
+++ b/src/elements_lagrange.jl
@@ -3,10 +3,7 @@
 
 using FEMBasis
 
-#    "Poi1" => (0, 1),
-"1 node discrete point element",
-type Poi1 <: AbstractBasis
-end
+struct Poi1 <: AbstractBasis end
 
 function get_basis(::Element{Poi1}, ::Any, ::Any)
     return [1]
@@ -50,7 +47,7 @@ function inside(::Union{Type{Tri3}, Type{Tri6}, Type{Tri7}, Type{Tet4}, Type{Tet
     return all(xi .>= 0.0) && (sum(xi) <= 1.0)
 end
 
-function get_reference_coordinates{B}(::Element{B})
+function get_reference_coordinates(::Element{B}) where B
     return get_reference_element_coordinates(B)
 end
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -245,7 +245,7 @@ function interpolate_field(field::DVTVd{T}, time) where T
             y0 = field.data[i-1].second
             y1 = field.data[i].second
             f = (time-t0)/(t1-t0)
-            new_data = similar(y0)
+            new_data = empty(y0)
             for i in keys(y0)
                 new_data[i] = f*y0[i] + (1-f)*y1[i]
             end

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -27,9 +27,9 @@ end
 abstract type AbstractLinearSystemSolver end
 
 function solve!(::LinearSystem, ::Solver) where Solver<:AbstractLinearSystemSolver
-    info("This is a placeholder function for solving linear systems")
-    info("To solve linear systems, you must define a function")
-    info("      solve!(system::LinearSystem, solver::$Solver)")
+    @info("This is a placeholder function for solving linear systems. To solve " *
+          "linear systems, you must define a function " *
+          "solve!(system::LinearSystem, solver::$Solver)")
 end
 
 function can_solve(::LinearSystem, ::Solver) where Solver<:AbstractLinearSystemSolver
@@ -41,7 +41,7 @@ function solve!(ls::LinearSystem, solvers::Vector{S}) where S<:AbstractLinearSys
         Solver = typeof(solver)
         cansolve, msg = can_solve(ls, solver)
         if !cansolve
-            info("Solver $Solver cannot solve linear system: $msg")
+            @info("Solver $Solver cannot solve linear system: $msg")
             continue
         end
         timeit("solve linear system using solver $Solver") do

--- a/src/types.jl
+++ b/src/types.jl
@@ -33,16 +33,12 @@ function (point::Point)(field_name, time)
     interpolate(point.fields[field_name], time)
 end
 
-function start(point::Point)
-    return start(point.coords)
+function Base.iterate(point::Point)
+    return Base.iterate(point.coords)
 end
 
-function done(point::Point, i)
-    return done(point.coords, i)
-end
-
-function next(point::Point, i)
-    return next(point.coords, i)
+function Base.iterate(point::Point, i::Int)
+    return Base.iterate(point.coords, i)
 end
 
 function update!(point::Point, field_name, val::Pair{Float64, T}) where T
@@ -61,7 +57,7 @@ type MaterialPoint <: AbstractPoint
 end
 =#
 
-mutable struct IntegrationPoint <: AbstractPoint
+struct IntegrationPoint <: AbstractPoint
 end
 
 const IP = Point{IntegrationPoint}
@@ -71,6 +67,6 @@ function IP(id, weight, coords::Tuple)
 end
 
 function IP(id, weight, coords::Vector)
-    warn("Consider giving coords as Tuple.")
+    @warn "Consider giving coordinates as tuple."
     return IP(id, weight, tuple(coords...), Dict(), IntegrationPoint())
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,29 +1,17 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
-using Base.Test
-using TimerOutputs
-const to = TimerOutput()
-
-test_files = String[]
-push!(test_files, "test_assembly.jl")
-push!(test_files, "test_elements.jl")
-push!(test_files, "test_fields.jl")
-push!(test_files, "test_integrate.jl")
-push!(test_files, "test_problems.jl")
-push!(test_files, "test_sparse.jl")
-push!(test_files, "test_solvers.jl")
-push!(test_files, "test_analysis.jl")
-push!(test_files, "test_test.jl")
-push!(test_files, "test_types.jl")
+using LinearAlgebra, Test
 
 @testset "FEMBase.jl" begin
-    for fn in test_files
-        timeit(to, fn) do
-            include(fn)
-        end
-    end
+    @testset "test_assembly" begin include("test_assembly.jl") end
+    @testset "test_elements" begin include("test_elements.jl") end
+    @testset "test_fields" begin include("test_fields.jl") end
+    @testset "test_integrate" begin include("test_integrate.jl") end
+    @testset "test_problems" begin include("test_problems.jl") end
+    @testset "test_sparse" begin include("test_sparse.jl") end
+    @testset "test_solvers" begin include("test_solvers.jl") end
+    @testset "test_analysis" begin include("test_analysis.jl") end
+    @testset "test_test" begin include("test_test.jl") end
+    @testset "test_types" begin include("test_types.jl") end
 end
-println()
-println("Test statistics:")
-println(to)

--- a/test/test_add_elements.jl
+++ b/test/test_add_elements.jl
@@ -2,10 +2,9 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
 using FEMBase
-using Base.Test
+using Test
 
-mutable struct Dummy <: FEMBase.FieldProblem
-end
+struct Dummy <: FEMBase.FieldProblem end
 
 @testset "add elements to problem" begin
     problem = Problem(Dummy, "test", 2)

--- a/test/test_analysis.jl
+++ b/test/test_analysis.jl
@@ -2,14 +2,14 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
 using FEMBase
-using FEMBase.get_problems
-using Base.Test
+using FEMBase: get_problems
+using Test
 
 import FEMBase: run!
 
-mutable struct MyAnalysis1 <: AbstractAnalysis end
+struct MyAnalysis1 <: AbstractAnalysis end
 
-mutable struct MyAnalysis2 <: AbstractAnalysis end
+struct MyAnalysis2 <: AbstractAnalysis end
 
 mutable struct MyProblem <: FieldProblem
     value :: Bool

--- a/test/test_assembly.jl
+++ b/test/test_assembly.jl
@@ -3,10 +3,10 @@
 
 using FEMBase
 using FEMBase: assemble_mass_matrix!
-using Base.Test
+using Test
 
-mutable struct Dummy <: FieldProblem end
-mutable struct Dummy2 <: FieldProblem end
+struct Dummy <: FieldProblem end
+struct Dummy2 <: FieldProblem end
 
 @testset "test tet4 mass matrix" begin
     X = Dict(
@@ -22,18 +22,15 @@ mutable struct Dummy2 <: FieldProblem end
     p = Problem(Dummy, "test", 1)
     add_elements!(p, [element])
     assemble_mass_matrix!(p, 0.0)
-    M = full(p.assembly.M)
-
     M_expected = [
                   2 1 1 1
                   1 2 1 1
                   1 1 2 1
                   1 1 1 2
                  ]
-    @test isapprox(M, M_expected)
+    @test isapprox(p.assembly.M, M_expected)
     assemble_mass_matrix!(p, 0.0)
-    M = full(p.assembly.M)
-    @test isapprox(M, M_expected)
+    @test isapprox(p.assembly.M, M_expected)
 end
 
 @testset "test tet10 mass matrix" begin
@@ -56,7 +53,6 @@ end
     p = Problem(Dummy, "test", 1)
     add_elements!(p, [element])
     assemble_mass_matrix!(p, 0.0)
-    M = full(p.assembly.M)
 
     M_expected = [
         6   1   1   1  -4  -6  -4  -4  -6  -6 
@@ -70,13 +66,12 @@ end
        -6  -4  -6  -4  16  16   8  16  32  16
        -6  -6  -4  -4   8  16  16  16  16  32]
 
-    @test isapprox(M, M_expected)
+    @test isapprox(p.assembly.M, M_expected)
 
-    X[5] += 0.1
+    X[5] .+= 0.1
     update!(element, "geometry", X)
     empty!(p.assembly.M)
     assemble_mass_matrix!(p, 0.0)
-    M = full(p.assembly.M)
 end
 
 @testset "add, empty and compare assembly" begin
@@ -108,7 +103,7 @@ end
     K_expected = zeros(3,3)
     K_expected[1:2,1:2] += k
     K_expected[2:3,2:3] += k
-    @test isapprox(full(p.assembly.K), K_expected)
+    @test isapprox(p.assembly.K, K_expected)
     assemble!(p, 0.0)
-    @test isapprox(full(p.assembly.K), 2.0*K_expected)
+    @test isapprox(p.assembly.K, 2.0*K_expected)
 end

--- a/test/test_common_failures.jl
+++ b/test/test_common_failures.jl
@@ -2,9 +2,9 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
 using FEMBase
-using Base.Test
+using Test
 
-mutable struct Dummy <: FieldProblem end
+struct Dummy <: FieldProblem end
 
 @testset "no unknown field name or assemble!-function defined" begin
     el = Element(Quad4, [1, 2, 3, 4])

--- a/test/test_elements_2.jl
+++ b/test/test_elements_2.jl
@@ -3,7 +3,7 @@
 
 using FEMBase
 using FEMBase: get_local_coordinates, inside
-using Base.Test
+using Test
 
 @testset "inverse isoparametric mapping" begin
     el = Element(Quad4, [1, 2, 3, 4])

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -2,7 +2,7 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
 using FEMBase
-using Base.Test
+using Test
 
 @testset "DCTI field" begin
 

--- a/test/test_integrate.jl
+++ b/test/test_integrate.jl
@@ -2,7 +2,7 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
 using FEMBase
-using Base.Test
+using Test
 
 @testset "test integrate" begin
     element = Element(Seg2, [1, 2])

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -1,9 +1,7 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
-using FEMBase
-using Base.Test
-
+using FEMBase, Test, SparseArrays
 import FEMBase: solve!, can_solve
 
 mutable struct LSSolver1 <: AbstractLinearSystemSolver
@@ -33,6 +31,6 @@ end
     solve!(ls, solver1)
     @test can_solve(ls, solver1)[1] == false
     solve!(ls, [solver1, solver2])
-    @test isapprox(ls.u, sparse(ones(3)))
+    @test isapprox(ls.u, ones(3))
     @test_throws ErrorException solve!(ls, [solver1])
 end

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -2,23 +2,24 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
 using FEMBase
-using FEMBase: SparseMatrixCOO, SparseVectorCOO, optimize!
+using FEMBase: SparseMatrixCOO, SparseVectorCOO
 using FEMBase: resize_sparse, resize_sparsevec
 using FEMBase: get_nonzero_rows, get_nonzero_columns
-using Base.Test
+using Test
+using SparseArrays
 
 @testset "Add to SparseMatrixCOO" begin
     A = SparseMatrixCOO()
     A2 = reshape(collect(1:9), 3, 3)
     add!(A, sparse(A2))
-    @test isapprox(full(A), full(A2))
+    @test isapprox(A, A2)
 end
 
 @testset "Add to SparseVectorCOO" begin
     b = SparseVectorCOO()
     b2 = collect(1:3)
     add!(b, sparse(b2))
-    @test isapprox(full(b), full(b2))
+    @test isapprox(b, b2)
 end
 
 @testset "Failure to add data to sparse vector due dimension mismatch" begin
@@ -26,23 +27,11 @@ end
     @test_throws ErrorException add!(b, [1, 2], [1.0, 2.0, 3.0])
 end
 
-@testset "Test combining of SparseMatrixCOO" begin
-    k = convert(Matrix{Float64}, reshape(collect(1:9), 3, 3))
-    dofs1 = [1, 2, 3]
-    dofs2 = [2, 3, 4]
-    A = SparseMatrixCOO()
-    add!(A, dofs1, dofs1, k)
-    add!(A, dofs2, dofs2, k)
-    A1 = full(A)
-    optimize!(A)
-    A2 = full(A)
-    @test isapprox(A1, A2)
-end
-
 @testset "resize of sparse matrix and sparse vector" begin
     A = sparse(rand(3, 3))
     B = resize_sparse(A, 4, 4)
     @test size(B) == (4, 4)
+
     a = sparse(rand(3))
     b = resize_sparsevec(a, 4)
     @test size(b) == (4, )
@@ -52,11 +41,11 @@ end
     A = reshape(collect(1:9), 3, 3)
     A2 = convert(SparseMatrixCOO, A)
     A3 = convert(SparseMatrixCOO, sparse(A))
-    @test isapprox(A, full(A2))
-    @test isapprox(A, full(A3))
+    @test isapprox(A, A2)
+    @test isapprox(A, A3)
     b = sparse(collect(1:3))
     b2 = convert(SparseVectorCOO, b)
-    @test isapprox(b, full(b2))
+    @test isapprox(b, b2)
 end
 
 @testset "construct sparse matrix and empty it" begin

--- a/test/test_test.jl
+++ b/test/test_test.jl
@@ -2,7 +2,7 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
 using FEMBase
-using FEMBase.Test
+using FEMBase.FEMTest
 
 @testset "Poisson + Dirichlet" begin
     el1 = Element(Quad4, [1, 2, 3, 4])
@@ -62,7 +62,7 @@ end
 
 @testset "Test @test_resource" begin
     fn = @test_resource("mesh.inp")
-    @test contains(fn, "mesh.inp")
+    @test occursin("mesh.inp", fn)
 end
 
 @testset "Test read_mtx_from_file and read_mtx_from_string" begin

--- a/test/test_time_interpolate.jl
+++ b/test/test_time_interpolate.jl
@@ -2,7 +2,7 @@
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
 using FEMBase
-using FEMBase.Test
+using Test
 
 # Time interpolation of fields
 

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -3,7 +3,7 @@
 
 using FEMBase
 using FEMBase: IP
-using Base.Test
+using Test
 
 @testset "test integration point" begin
     a = sqrt(1.0/3.0)


### PR DESCRIPTION
One method was removed, looks that `optimize!(A::SparseMatrixCOO)` is
not doing anything useful.