### PR TITLE
Small changes in API

### DIFF
--- a/src/FEMBase.jl
+++ b/src/FEMBase.jl
@@ -30,7 +30,7 @@ include("elements_lagrange.jl")
 include("integrate.jl")
 
 include("problems.jl")
-export set_gdofs!, get_gdofs, get_formulation_type
+export set_gdofs!, get_gdofs, get_formulation_type, add_element!, add_elements!
 
 include("assembly.jl")
 export assemble_prehook!, assemble_posthook!, assemble_elements!
@@ -41,12 +41,12 @@ export LinearSystem, AbstractLinearSystemSolver, solve!
 include("analysis.jl")
 export AbstractAnalysis, Analysis, add_problems!, get_problems, run!,
        AbstractResultsWriter, add_results_writer!, get_results_writers,
-       write_results!
+       write_results!, get_problem
 
 export FieldProblem, BoundaryProblem, Problem, Element, Assembly
 export Poi1, Seg2, Seg3, Tri3, Tri6, Tri7, Quad4, Quad8, Quad9,
        Tet4, Tet10, Pyr5, Wedge6, Wedge15, Hex8, Hex20, Hex27
-export add_elements!, add!, group_by_element_type,
+export add!, group_by_element_type,
        get_unknown_field_name, get_unknown_field_dimension,
        get_integration_points, initialize!, assemble!
 export SparseMatrixCOO, SparseVectorCOO, Node, BasisInfo,

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -375,11 +375,6 @@ function interpolate(a, b)
     return sum(a[i]*b[i] for i=1:length(a))
 end
 
-"""
-    update!(field, data)
-
-Update new value to field.
-"""
 function update!(field::F, data) where F<:AbstractField
     update_field!(field, data)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
-using LinearAlgebra, Test
+using FEMBase, Test, LinearAlgebra, SparseArrays, Statistics
 
-include("../docs/make.jl")
+include(joinpath("..", "docs", "make.jl"))
 
 @testset "FEMBase.jl" begin
     @testset "test_assembly" begin include("test_assembly.jl") end
@@ -18,4 +18,4 @@ include("../docs/make.jl")
     @testset "test_types" begin include("test_types.jl") end
 end
 
-include("../docs/deploy.jl")
+include(joinpath("..", "docs", "deploy.jl"))

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -50,7 +50,7 @@ end
 
 @testset "construct sparse matrix and empty it" begin
     A = SparseMatrixCOO()
-    push!(A, 1, 1, 1.0)
+    add!(A, 1, 1, 1.0)
     A_expected = sparse([1], [1], [1.0], 2, 2)
     A2 = sparse(A, 2, 2)
     @test isapprox(A2, A_expected)
@@ -60,8 +60,8 @@ end
 
 @testset "construct sparse matrix with special function" begin
     A = SparseMatrixCOO()
-    push!(A, 1, 1, 1.0)
-    push!(A, 1, 1, 2.0)
+    add!(A, 1, 1, 1.0)
+    add!(A, 1, 1, 2.0)
     B = sparse(A, 2, 2, +)
     @test isapprox(B[1,1], 3.0)
 end


### PR DESCRIPTION
* New function get_problem(problem, name) to fetch a problem from the analysis.
* Update docstrings.
* Connectivity can be given with tuple when creating new element.
* Be more information (@info) when calling functions to be more responsible.
* Preparations to separate topology and basis.
* Remove function to update properties with string pairs, it's quite an unpractical approach (we still should implement something like update_properties!(...) ).
* `add_elements!`, `add_problems!`, takes also varargs, so can also call `add_elements!(p, e1, e2)` instead of creating first iterable.
* `update!` can take list of elements as tuple.
* `SparseMatrixCOO` and `SparseVectorCOO` can be converted to full matrices / vectors using `Matrix` and `Vector`.
* Comparison of `SparseMatrixCOO` with matrix / vector using `isapprox`.
* `add!` returns nothing.