### PR TITLE
prefix with package name for foreign names

### DIFF
--- a/src/FEMBase.jl
+++ b/src/FEMBase.jl
@@ -9,17 +9,16 @@ macro lintpragma(s)
 end
 
 import Base: getindex, setindex!, convert, length, size, isapprox,
-             start, first, next, done, last, endof, vec,
+             first, last, vec,
              ==, +, -, *, /, haskey, copy, push!, isempty, empty!,
              append!, read
 
 using TimerOutputs
 export @timeit, print_timer
 
-using FEMBasis
-using FEMBasis: AbstractBasis, jacobian, get_reference_element_coordinates
-import FEMBasis: interpolate
-using FEMQuad: get_quadrature_points
+import FEMBasis
+import FEMQuad
+
 include("fields.jl")
 export interpolate, update!, DCTI, DCTV, DVTI, DVTV, CVTV, DVTId, DVTVd, field
 include("types.jl")
@@ -44,8 +43,6 @@ export AbstractAnalysis, Analysis, add_problems!, get_problems, run!,
        write_results!, get_problem
 
 export FieldProblem, BoundaryProblem, Problem, Element, Assembly
-export Poi1, Seg2, Seg3, Tri3, Tri6, Tri7, Quad4, Quad8, Quad9,
-       Tet4, Tet10, Pyr5, Wedge6, Wedge15, Hex8, Hex20, Hex27
 export add!, group_by_element_type,
        get_unknown_field_name, get_unknown_field_dimension,
        get_integration_points, initialize!, assemble!
@@ -77,5 +74,9 @@ export add_master_elements!
 
 function get_master_elements end
 export get_master_elements
+
+using FEMBasis
+export Poi1, Seg2, Seg3, Tri3, Tri6, Tri7, Quad4, Quad8, Quad9,
+       Tet4, Tet10, Pyr5, Wedge6, Wedge15, Hex8, Hex20, Hex27
 
 end

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -143,7 +143,7 @@ end
 Assemble Tet10 mass matrices using special method. If Tet10 has constant metric
 if can be integrated analytically to gain performance.
 """
-function assemble_mass_matrix!(problem::Problem, elements::Vector{Element{Tet10}}, time)
+function assemble_mass_matrix!(problem::Problem, elements::Vector{Element{FEMBasis.Tet10}}, time)
     nnodes = length(Tet10)
     dim = get_unknown_field_dimension(problem)
     M = zeros(nnodes, nnodes)
@@ -163,7 +163,7 @@ function assemble_mass_matrix!(problem::Problem, elements::Vector{Element{Tet10}
         -6 -4 -6 -4 16 16  8 16 32 16
         -6 -6 -4 -4  8 16 16 16 16 32]
 
-    function is_CM(::Element{Tet10}, X; rtol=1.0e-6)
+    function is_CM(::Element{FEMBasis.Tet10}, X; rtol=1.0e-6)
         isapprox(X[5],  1/2*(X[1]+X[2]); rtol=rtol) || return false
         isapprox(X[6],  1/2*(X[2]+X[3]); rtol=rtol) || return false
         isapprox(X[7],  1/2*(X[3]+X[1]); rtol=rtol) || return false
@@ -197,7 +197,7 @@ function assemble_mass_matrix!(problem::Problem, elements::Vector{Element{Tet10}
                 detJ = element(ip, time, Val{:detJ})
                 rho = element("density", ip, time)
                 w = ip.weight*rho*detJ
-                eval_basis!(Tet10, N, ip)
+                eval_basis!(FEMBasis.Tet10, N, ip)
                 N = element(ip, time)
                 mul!(NtN, transpose(N), N)
                 rmul!(NtN, w)

--- a/src/elements_lagrange.jl
+++ b/src/elements_lagrange.jl
@@ -1,9 +1,7 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
 
-using FEMBasis
-
-struct Poi1 <: AbstractBasis end
+struct Poi1 <: FEMBasis.AbstractBasis end
 
 function get_basis(::Element{Poi1}, ::Any, ::Any)
     return [1]
@@ -37,13 +35,15 @@ function FEMBasis.get_reference_element_coordinates(::Type{Poi1})
     Vector{Float64}[[0.0]]
 end
 
-function inside(::Union{Type{Seg2}, Type{Seg3}, Type{Quad4}, Type{Quad8},
-                        Type{Quad9}, Type{Pyr5}, Type{Hex8}, Type{Hex20},
-                        Type{Hex27}}, xi)
+function inside(::Union{Type{FEMBasis.Seg2}, Type{FEMBasis.Seg3}, Type{FEMBasis.Quad4},
+                        Type{FEMBasis.Quad8}, Type{FEMBasis.Quad9}, Type{FEMBasis.Pyr5},
+                        Type{FEMBasis.Hex8}, Type{FEMBasis.Hex20},
+                        Type{FEMBasis.Hex27}}, xi)
     return all(-1.0 .<= xi .<= 1.0)
 end
 
-function inside(::Union{Type{Tri3}, Type{Tri6}, Type{Tri7}, Type{Tet4}, Type{Tet10}}, xi)
+function inside(::Union{Type{FEMBasis.Tri3}, Type{FEMBasis.Tri6}, Type{FEMBasis.Tri7},
+                        Type{FEMBasis.Tet4}, Type{FEMBasis.Tet10}}, xi)
     return all(xi .>= 0.0) && (sum(xi) <= 1.0)
 end
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -360,7 +360,7 @@ time of some frame and return that frame. At last, we find correct bin so
 that t0 < time < t1 and use linear interpolation.
 
 """
-function interpolate(field::F, time) where F<:AbstractField
+function interpolate(field::AbstractField, time)
     return interpolate_field(field, time)
 end
 
@@ -375,6 +375,6 @@ function interpolate(a, b)
     return sum(a[i]*b[i] for i=1:length(a))
 end
 
-function update!(field::F, data) where F<:AbstractField
+function update!(field::AbstractField, data)
     update_field!(field, data)
 end

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -16,10 +16,10 @@ integration_rule_mapping = (
     :Quad8   => (:GLQUAD9, :GLQUAD16, :GLQUAD25),
     :Quad9   => (:GLQUAD9, :GLQUAD16, :GLQUAD25),
     :NSurf   => (:GLQUAD9, :GLQUAD16, :GLQUAD25),
-    :Hex8    => (:GLHEX8, :GLHEX27, :GLHEX81, :GLHEX243),
-    :Hex20   => (:GLHEX27, :GLHEX81, :GLHEX243),
-    :Hex27   => (:GLHEX27, :GLHEX81, :GLHEX243),
-    :NSolid  => (:GLHEX27, :GLHEX81, :GLHEX243),
+    :Hex8    => (:GLHEX8, :GLHEX27, :GLHEX64, :GLHEX125),
+    :Hex20   => (:GLHEX27, :GLHEX64, :GLHEX125),
+    :Hex27   => (:GLHEX27, :GLHEX64, :GLHEX125),
+    :NSolid  => (:GLHEX27, :GLHEX64, :GLHEX125),
     :Tri3    => (:GLTRI1, :GLTRI3, :GLTRI4, :GLTRI6, :GLTRI7, :GLTRI12),
     :Tri6    => (:GLTRI3, :GLTRI4, :GLTRI6, :GLTRI7, :GLTRI12),
     :Tri7    => (:GLTRI3, :GLTRI4, :GLTRI6, :GLTRI7, :GLTRI12),
@@ -35,14 +35,14 @@ for (E, R) in integration_rule_mapping
         order = Val{i-1}
         if i == 1
             code = quote
-                function get_integration_points(element::$E)
-                    return get_quadrature_points($P)
+                function get_integration_points(element::FEMBasis.$E)
+                    return FEMQuad.get_quadrature_points($P)
                 end
             end
         else
             code = quote
-                function get_integration_points(element::$E, ::Type{$order})
-                    return get_quadrature_points($P)
+                function get_integration_points(element::FEMBasis.$E, ::Type{$order})
+                    return FEMQuad.get_quadrature_points($P)
                 end
             end
         end

--- a/src/test.jl
+++ b/src/test.jl
@@ -22,7 +22,8 @@ using Test, LinearAlgebra, SparseArrays
 export @test, @test_throws, @test_broken, @test_skip,
        @test_warn, @test_nowarn, @testset, @inferred
 
-using FEMBase
+using ..FEMBase
+import ..FEMBasis
 
 struct Poisson <: FieldProblem end
 
@@ -35,7 +36,7 @@ function FEMBase.assemble_elements!(problem::Problem{Poisson},
                                     elements::Vector{Element{E}},
                                     time::Float64) where E
 
-    bi = BasisInfo(E)
+    bi = FEMBasis.BasisInfo(E)
     ndofs = length(bi)
     Ke = zeros(ndofs, ndofs)
     fe = zeros(ndofs)
@@ -64,9 +65,9 @@ end
 function FEMBase.assemble_elements!(problem::Problem{Poisson},
                                     assembly::Assembly,
                                     elements::Vector{Element{E}},
-                                    time::Float64) where E<:Union{Seg2,Seg3}
+                                    time::Float64) where E<:Union{FEMBasis.Seg2,FEMBasis.Seg3}
 
-    bi = BasisInfo(E)
+    bi = FEMBasis.BasisInfo(E)
     ndofs = length(bi)
     Ce = zeros(ndofs, ndofs)
     fe = zeros(ndofs)
@@ -112,7 +113,7 @@ function FEMBase.assemble_elements!(problem::Problem{Dirichlet},
             haskey(element, "$name $i") || continue
             gdofs = get_gdofs(problem, element)
             ldofs = gdofs[i:dim:end]
-            xis = get_reference_element_coordinates(E)
+            xis = FEMBasis.get_reference_element_coordinates(E)
             for (ldof, xi) in zip(ldofs, xis)
                 data[ldof] = interpolate(element, "$name $i", xi, time)
             end


### PR DESCRIPTION
I was getting to know the code base but I found it quite difficult since I would look for a name and then found out it was defined in another package (like FEMBasis).

This PR adds prefixes to the names that are defined in other packages.
It also updates with the changes + fixes in https://github.com/JuliaFEM/FEMQuad.jl/pull/15 (fixing names of HEX81 & co, and returning a length 1 tuple for 1 dim quadrature rules).

PR will fail until we either checkout the FEMQuad branch or tag it or something (one of the drawbacks with splitting things into multiple packages heh).