### PR TITLE
Have two set of fields

### DIFF
--- a/src/FEMBase.jl
+++ b/src/FEMBase.jl
@@ -79,4 +79,6 @@ using FEMBasis
 export Poi1, Seg2, Seg3, Tri3, Tri6, Tri7, Quad4, Quad8, Quad9,
        Tet4, Tet10, Pyr5, Wedge6, Wedge15, Hex8, Hex20, Hex27
 
+include("deprecated.jl")
+
 end

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -15,25 +15,6 @@ function assemble_prehook!(::Problem, ::T) where T<:Number end
 
 function assemble_posthook!(::Problem, ::T) where T<:Number end
 
-# will be deprecated
-function assemble!(::Assembly, ::Problem{P}, ::Element, ::Any) where P
-    @warn("One must define assemble! function for problem of type $P. " *
-          "Not doing anything.")
-    return nothing
-end
-
-# will be deprecated
-function assemble!(assembly::Assembly, problem::Problem{P},
-                   elements::Vector{Element}, time) where P
-    @warn("This is default assemble! function. Decreased performance can be " *
-          "expected without preallocation of memory. One should implement " *
-          "`assemble_elements!(problem, assembly, elements, time)` function.")
-    for element in elements
-        assemble!(assembly, problem, element, time)
-    end
-    return nothing
-end
-
 """
     assemble_elements!(problem, assembly, elements, time)
 

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -23,7 +23,7 @@ Assemble elements for problem.
 This should be overridden with own `assemble_elements!`-implementation.
 """
 function assemble_elements!(problem::Problem, assembly::Assembly,
-                      elements::Vector{Element{E}}, time) where E
+                            elements::Vector{T}, time) where T<:AbstractElement{E} where E
     elements2 = convert(Vector{Element}, elements)
     assemble!(assembly, problem, elements2, time)
 end
@@ -87,7 +87,7 @@ function assemble_mass_matrix!(problem::Problem, time::Float64)
     return nothing
 end
 
-function assemble_mass_matrix!(problem::Problem, elements::Vector{Element{Basis}}, time) where Basis
+function assemble_mass_matrix!(problem::Problem, elements::Vector{E}, time) where E<:AbstractElement{Basis} where Basis
     nnodes = length(first(elements))
     dim = get_unknown_field_dimension(problem)
     M = zeros(nnodes, nnodes)
@@ -124,7 +124,7 @@ end
 Assemble Tet10 mass matrices using special method. If Tet10 has constant metric
 if can be integrated analytically to gain performance.
 """
-function assemble_mass_matrix!(problem::Problem, elements::Vector{Element{FEMBasis.Tet10}}, time)
+function assemble_mass_matrix!(problem::Problem, elements::Vector{E}, time) where E<:AbstractElement{FEMBasis.Tet10}
     nnodes = length(Tet10)
     dim = get_unknown_field_dimension(problem)
     M = zeros(nnodes, nnodes)
@@ -144,7 +144,7 @@ function assemble_mass_matrix!(problem::Problem, elements::Vector{Element{FEMBas
         -6 -4 -6 -4 16 16  8 16 32 16
         -6 -6 -4 -4  8 16 16 16 16 32]
 
-    function is_CM(::Element{FEMBasis.Tet10}, X; rtol=1.0e-6)
+    function is_CM(::AbstractElement{FEMBasis.Tet10}, X; rtol=1.0e-6)
         isapprox(X[5],  1/2*(X[1]+X[2]); rtol=rtol) || return false
         isapprox(X[6],  1/2*(X[2]+X[3]); rtol=rtol) || return false
         isapprox(X[7],  1/2*(X[3]+X[1]); rtol=rtol) || return false

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -87,7 +87,7 @@ function assemble_mass_matrix!(problem::Problem, time::Float64)
     return nothing
 end
 
-function assemble_mass_matrix!(problem::Problem, elements::Vector{E}, time) where E<:AbstractElement{Basis} where Basis
+function assemble_mass_matrix!(problem::Problem, elements::Vector{E}, time) where E<:AbstractElement{M_,B} where {M_,B}
     nnodes = length(first(elements))
     dim = get_unknown_field_dimension(problem)
     M = zeros(nnodes, nnodes)
@@ -100,7 +100,7 @@ function assemble_mass_matrix!(problem::Problem, elements::Vector{E}, time) wher
             detJ = element(ip, time, Val{:detJ})
             rho = element("density", ip, time)
             w = ip.weight*rho*detJ
-            eval_basis!(Basis, N, ip)
+            eval_basis!(B, N, ip)
             N = element(ip, time)
             mul!(NtN, transpose(N), N)
             rmul!(NtN, w)
@@ -124,7 +124,7 @@ end
 Assemble Tet10 mass matrices using special method. If Tet10 has constant metric
 if can be integrated analytically to gain performance.
 """
-function assemble_mass_matrix!(problem::Problem, elements::Vector{E}, time) where E<:AbstractElement{FEMBasis.Tet10}
+function assemble_mass_matrix!(problem::Problem, elements::Vector{E}, time) where E<:AbstractElement{M_, FEMBasis.Tet10} where M_
     nnodes = length(Tet10)
     dim = get_unknown_field_dimension(problem)
     M = zeros(nnodes, nnodes)
@@ -144,7 +144,7 @@ function assemble_mass_matrix!(problem::Problem, elements::Vector{E}, time) wher
         -6 -4 -6 -4 16 16  8 16 32 16
         -6 -6 -4 -4  8 16 16 16 16 32]
 
-    function is_CM(::AbstractElement{FEMBasis.Tet10}, X; rtol=1.0e-6)
+    function is_CM(::AbstractElement{M, FEMBasis.Tet10}, X; rtol=1.0e-6) where M
         isapprox(X[5],  1/2*(X[1]+X[2]); rtol=rtol) || return false
         isapprox(X[6],  1/2*(X[2]+X[3]); rtol=rtol) || return false
         isapprox(X[7],  1/2*(X[3]+X[1]); rtol=rtol) || return false

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -6,7 +6,7 @@
 
 Return the length of basis (number of nodes).
 """
-function length(element::Element)
+function length(element::AbstractElement)
     return length(element.properties)
 end
 
@@ -15,20 +15,20 @@ end
 
 Return the size of basis (dim, nnodes).
 """
-function size(element::Element)
+function size(element::AbstractElement)
     return size(element.properties)
 end
 
-function getindex(element::Element, field_name::String)
+function getindex(element::AbstractElement, field_name::String)
     return element.fields[field_name]
 end
 
-function setindex!(element::Element, data::T, field_name) where T<:AbstractField
+function setindex!(element::AbstractElement, data::T, field_name) where T<:AbstractField
     element.fields[field_name] = data
 end
 
-function setindex!(element::Element, data::Function, field_name)
-    if hasmethod(data, Tuple{Element, Vector, Float64})
+function setindex!(element::AbstractElement, data::Function, field_name)
+    if hasmethod(data, Tuple{AbstractElement, Vector, Float64})
         # create enclosure to pass element as argument
         element.fields[field_name] = field((ip,time) -> data(element,ip,time))
     else
@@ -36,7 +36,7 @@ function setindex!(element::Element, data::Function, field_name)
     end
 end
 
-function setindex!(element::Element, data, field_name)
+function setindex!(element::AbstractElement, data, field_name)
     element.fields[field_name] = field(data)
 end
 
@@ -52,12 +52,12 @@ function (element::Element)(field_name::String)
     return element[field_name]
 end
 
-function size(element::Element, dim)
+function size(element::AbstractElement, dim)
     return size(element)[dim]
 end
 
 """ Check existence of field. """
-function haskey(element::Element, field_name)
+function haskey(element::AbstractElement, field_name)
     return haskey(element.fields, field_name)
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,86 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
+
+"""
+    length(element)
+
+Return the length of basis (number of nodes).
+"""
+function length(element::Element)
+    return length(element.properties)
+end
+
+"""
+    size(element)
+
+Return the size of basis (dim, nnodes).
+"""
+function size(element::Element)
+    return size(element.properties)
+end
+
+function getindex(element::Element, field_name::String)
+    return element.fields[field_name]
+end
+
+function setindex!(element::Element, data::T, field_name) where T<:AbstractField
+    element.fields[field_name] = data
+end
+
+function setindex!(element::Element, data::Function, field_name)
+    if hasmethod(data, Tuple{Element, Vector, Float64})
+        # create enclosure to pass element as argument
+        element.fields[field_name] = field((ip,time) -> data(element,ip,time))
+    else
+        element.fields[field_name] = field(data)
+    end
+end
+
+function setindex!(element::Element, data, field_name)
+    element.fields[field_name] = field(data)
+end
+
+#""" Return a Field object from element.
+#Examples
+#--------
+#>>> element = Element(Seg2, [1, 2])
+#>>> data = Dict(1 => 1.0, 2 => 2.0)
+#>>> update!(element, "my field", data)
+#>>> element("my field")
+#"""
+function (element::Element)(field_name::String)
+    return element[field_name]
+end
+
+function size(element::Element, dim)
+    return size(element)[dim]
+end
+
+""" Check existence of field. """
+function haskey(element::Element, field_name)
+    return haskey(element.fields, field_name)
+end
+
+# will be deprecated
+function assemble!(::Assembly, ::Problem{P}, ::AbstractElement, ::Any) where P
+    @warn("One must define assemble! function for problem of type $P. " *
+          "Not doing anything.")
+    return nothing
+end
+
+# will be deprecated
+function assemble!(assembly::Assembly, problem::Problem{P},
+                   elements::Vector{Element}, time) where P
+    @warn("This is default assemble! function. Decreased performance can be " *
+          "expected without preallocation of memory. One should implement " *
+          "`assemble_elements!(problem, assembly, elements, time)` function.")
+    for element in elements
+        assemble!(assembly, problem, element, time)
+    end
+    return nothing
+end
+
+# generally a bad idea to have functions like update! not explicitly giving targe?
+function update!(field::AbstractField, data)
+    update_field!(field, data)
+end

--- a/src/elements_lagrange.jl
+++ b/src/elements_lagrange.jl
@@ -3,15 +3,15 @@
 
 struct Poi1 <: FEMBasis.AbstractBasis end
 
-function get_basis(::Element{Poi1}, ::Any, ::Any)
+function get_basis(::E, ::Any, ::Any) where E<:AbstractElement{Poi1}
     return [1]
 end
 
-function get_dbasis(::Element{Poi1}, ::Any, ::Any)
+function get_dbasis(::E, ::Any, ::Any) where E<:AbstractElement{Poi1}
     return [0]
 end
 
-function (::Element{Poi1})(::Any, ::Float64, ::Type{Val{:detJ}})
+function (::Element{Poi1})(::Any, ::Float64, ::Type{Val{:detJ}}) 
     return 1.0
 end
 
@@ -47,7 +47,7 @@ function inside(::Union{Type{FEMBasis.Tri3}, Type{FEMBasis.Tri6}, Type{FEMBasis.
     return all(xi .>= 0.0) && (sum(xi) <= 1.0)
 end
 
-function get_reference_coordinates(::Element{B}) where B
+function get_reference_coordinates(::E) where E<:AbstractElement{B} where B
     return get_reference_element_coordinates(B)
 end
 

--- a/src/elements_lagrange.jl
+++ b/src/elements_lagrange.jl
@@ -3,15 +3,15 @@
 
 struct Poi1 <: FEMBasis.AbstractBasis end
 
-function get_basis(::E, ::Any, ::Any) where E<:AbstractElement{Poi1}
+function get_basis(::E, ::Any, ::Any) where E<:AbstractElement{M, Poi1} where M
     return [1]
 end
 
-function get_dbasis(::E, ::Any, ::Any) where E<:AbstractElement{Poi1}
+function get_dbasis(::E, ::Any, ::Any) where E<:AbstractElement{M, Poi1} where M
     return [0]
 end
 
-function (::Element{Poi1})(::Any, ::Float64, ::Type{Val{:detJ}}) 
+function (::Element{M, Poi1})(::Any, ::Float64, ::Type{Val{:detJ}}) where M
     return 1.0
 end
 
@@ -47,7 +47,7 @@ function inside(::Union{Type{FEMBasis.Tri3}, Type{FEMBasis.Tri6}, Type{FEMBasis.
     return all(xi .>= 0.0) && (sum(xi) <= 1.0)
 end
 
-function get_reference_coordinates(::E) where E<:AbstractElement{B} where B
+function get_reference_coordinates(::E) where E<:AbstractElement{M,B} where {M,B}
     return get_reference_element_coordinates(B)
 end
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -36,8 +36,8 @@ function interpolate_field(field::AbstractField, ::Any)
     return field.data
 end
 
-function update_field!(field, data)
-    field.data = data
+function update_field!(field::AbstractField, data)
+   field.data = data
 end
 
 """

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -32,7 +32,7 @@ function getindex(f::F, i::Int) where F<:AbstractField
     return getindex(f.data, i)
 end
 
-function interpolate_field(field, ::Any)
+function interpolate_field(field::AbstractField, ::Any)
     return field.data
 end
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -233,8 +233,8 @@ function DVTVd(data::Pair{Float64,Dict{Int,T}}...) where T
 end
 
 function interpolate_field(field::DVTVd{T}, time) where T
-    time < first(field.data).first && return first(field.data).second
-    time > last(field.data).first && return last(field.data).second
+    time >= last(field.data).first && return last(field.data).second
+    time <= first(field.data).first && return first(field.data).second
     for i=reverse(1:length(field))
         isapprox(field.data[i].first, time) && return field.data[i].second
     end

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -374,7 +374,3 @@ function interpolate(a, b)
     @assert length(a) <= length(b)
     return sum(a[i]*b[i] for i=1:length(a))
 end
-
-function update!(field::AbstractField, data)
-    update_field!(field, data)
-end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -240,7 +240,7 @@ of the problem (Elasticity, Dirichlet, etc.), `element_name` is the name of a
 constructed element (see Element(element_type, connectivity_vector)) and `time`
 is the starting time of the initializing process.
 """
-function initialize!(problem::Problem, element::Element, time::Float64)
+function initialize!(problem::Problem, element::AbstractElement, time::Float64)
     field_name = get_unknown_field_name(problem)
     field_dim = get_unknown_field_dimension(problem)
     nnodes = length(element)
@@ -469,7 +469,7 @@ where `nid` is node id and `dim` is the dimension of problem. This formula
 arranges dofs so that first comes all dofs of node 1, then node 2 and so on:
 (u11, u12, u13, u21, u22, u23, ..., un1, un2, un3) for 3 dofs/node setting.
 """
-function get_gdofs(problem::Problem, element::Element)
+function get_gdofs(problem::Problem, element::AbstractElement)
     if haskey(problem.dofmap, element)
         return problem.dofmap[element]
     end

--- a/src/test.jl
+++ b/src/test.jl
@@ -33,8 +33,8 @@ end
 
 function FEMBase.assemble_elements!(problem::Problem{Poisson},
                                     assembly::Assembly,
-                                    elements::Vector{Element{E}},
-                                    time::Float64) where E
+                                    elements::Vector{Element{M,E}},
+                                    time::Float64) where {M,E}
 
     bi = FEMBasis.BasisInfo(E)
     ndofs = length(bi)
@@ -64,8 +64,8 @@ end
 
 function FEMBase.assemble_elements!(problem::Problem{Poisson},
                                     assembly::Assembly,
-                                    elements::Vector{Element{E}},
-                                    time::Float64) where E<:Union{FEMBasis.Seg2,FEMBasis.Seg3}
+                                    elements::Vector{Element{M,E}},
+                                    time::Float64) where {M,E<:Union{FEMBasis.Seg2,FEMBasis.Seg3}}
 
     bi = FEMBasis.BasisInfo(E)
     ndofs = length(bi)
@@ -101,8 +101,8 @@ struct Dirichlet <: BoundaryProblem end
 
 function FEMBase.assemble_elements!(problem::Problem{Dirichlet},
                                     assembly::Assembly,
-                                    elements::Vector{Element{E}},
-                                    time::Float64) where E
+                                    elements::Vector{Element{M,E}},
+                                    time::Float64) where {M,E}
 
     name = get_parent_field_name(problem)
     dim = get_unknown_field_dimension(problem)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,5 @@ using FEMBase, Test, LinearAlgebra, SparseArrays, Statistics
     @testset "test_test" begin include("test_test.jl") end
     @testset "test_types" begin include("test_types.jl") end
     @testset "test get integration points" begin include("test_get_integration_points.jl") end
+    @testset "test element fields" begin include("test_elements_fields.jl") end
 end

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -80,14 +80,19 @@ end
     @test isapprox(el([0.0, 0.0], 0.0, 2), expected)
 end
 
+## Grouping of elements
+
+# Element can be divided to groups by element type using command
+# `group_by_element_type`:
+
 @testset "group elements" begin
-    e1 = Element(Seg2, [1, 2])
-    e2 = Element(Quad4, [1, 2, 3, 4])
+    e1 = Element(Seg2, (1, 2))
+    e2 = Element(Quad4, (1, 2, 3, 4))
     elements = [e1, e2]
-    r = group_by_element_type(elements)
-    @test length(r) == 2
-    @test first(r[Element{Seg2}]) == e1
-    @test first(r[Element{Quad4}]) == e2
+    elgroups = group_by_element_type(elements)
+    @test length(elgroups) == 2
+    @test first(elgroups[typeof(e1)]) == e1
+    @test first(elgroups[typeof(e2)]) == e2
     @test get_element_type(e1) == Seg2
     e1.id = 1
     @test get_element_id(e1) == 1

--- a/test/test_elements_fields.jl
+++ b/test/test_elements_fields.jl
@@ -1,0 +1,81 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/FEMBase.jl/blob/master/LICENSE
+
+using FEMBase
+using Test
+
+## Elements - field sets
+
+# Each element have two kind of fields, dynamically defined and statically
+# defined.
+
+element = Element(Quad4, (1, 2, 3, 4))
+
+### Dynamically defined fields
+
+using FEMBase: has_dfield, get_dfield, create_dfield!, update_dfield!,
+               interpolate_dfield
+
+# Like name suggests, dynamically defined fields can be defined on fly.
+# For example, to define a fields called *geometry* and *displacement*:
+
+@test has_dfield(element, :geometry) == false
+
+X = ([0.0,0.0], [1.0,0.0], [1.0,1.0], [0.0,1.0])
+u0 = ([0.0,0.0], [0.0,0.0], [0.0,0.0], [0.0,0.0])
+u1 = ([0.0,0.0], [0.0,0.0], [1.0,0.0], [0.0,0.0])
+
+create_dfield!(element, :geometry, X)
+@test has_dfield(element, :geometry) == true
+
+create_dfield!(element, :displacement, 0.0 => u0)
+update_dfield!(element, :displacement, 1.0 => u1)
+
+# The main property of the dynamic fields are that they can be defined
+# abolutely in what state of simulation ever, without any predefined
+# initialization steps. `update_dfield!` is creating field on fly, if
+# it doesn't exists before hand.
+
+update_dfield!(element, :youngs_modulus, 288.0)
+@test has_dfield(element, :youngs_modulus)
+
+# If field depends from time (DVTV, DCTV, DVTVd, ...), interpolation
+# works as expected:
+
+um = interpolate_dfield(element, :displacement, 0.5)
+@test um[3] == [0.5, 0.0]
+
+
+### Common routines to dfields and sfields
+
+using FEMBase: has_field, get_field, update_field!, interpolate_field
+
+# There is common routines `has_field`, `update_field!`, `interpolate_field`
+# and so on, which tries to be clever. We prefer statically defined fields
+# as they outperform dynamically defined ones in access time, but then e.g.
+# if field is not statically defined, `update_field!` is creating a new dfield.
+
+@test has_field(element, :geometry) == true
+@test get_field(element, :youngs_modulus) === get_dfield(element, :youngs_modulus)
+update_field!(element, :poissons_ratio, 1/3)
+@test interpolate_field(element, :poissons_ratio, 0.0) == 1/3
+
+### Creating and updating DVTI and DVTV fields using dictionaries
+
+# It's a very convenient way to update fields using dictionaries.
+
+element = Element(Seg2, (1, 2))
+update!(element, :temperature, 0.0 => (0.0, 0.0))
+
+# Let say that one wants to update the following temperature data:
+
+T = Dict(1 => 1.0, 2 => 2.0, 3 => 3.0)
+
+# to a element, can be done using that dictionary:
+
+update!(element, :temperature, 1.0 => T)
+
+# Internally, we pick the data from dictionary based on the node numbers and
+# update only that data to element.
+
+@test interpolate(element, :temperature, 1.0) == (T[1], T[2])

--- a/test/test_elements_fields.jl
+++ b/test/test_elements_fields.jl
@@ -9,15 +9,15 @@ using Test
 # Each element have two kind of fields, dynamically defined and statically
 # defined.
 
-element = Element(Quad4, (1, 2, 3, 4))
-
-### Dynamically defined fields
+### Dynamically defined fields (dfields)
 
 using FEMBase: has_dfield, get_dfield, create_dfield!, update_dfield!,
                interpolate_dfield
 
 # Like name suggests, dynamically defined fields can be defined on fly.
 # For example, to define a fields called *geometry* and *displacement*:
+
+element = Element(Quad4, (1, 2, 3, 4))
 
 @test has_dfield(element, :geometry) == false
 
@@ -45,8 +45,56 @@ update_dfield!(element, :youngs_modulus, 288.0)
 um = interpolate_dfield(element, :displacement, 0.5)
 @test um[3] == [0.5, 0.0]
 
+### Statically defined fields (sfields)
+
+# The problem of the dynamically defined fields are that they have a poor
+# performance. Julia is JIT compiled language and from performance perspective,
+# knowing concrete types in compile time leads to fast implementation. For that
+# reason, we also have another fieldset, which must be given when a new element
+# is created, allowing high performance.
+
+using FEMBase: has_sfield, get_sfield, update_sfield!, interpolate_sfield, AbstractFieldSet
+
+struct MyFieldSet{N} <: AbstractFieldSet{N}
+    geometry :: DVTI{N, Vector{Float64}}
+    displacement :: DVTV{N, Vector{Float64}}
+end
+
+function MyFieldSet{N}() where N
+    # create tuple of length N with zeros(3): ([0.0,0.0,0.0], ..., )
+    data = ntuple(i -> zeros(3), N)
+    geometry = DVTI(data)
+    displacement = DVTV(0.0 => data)
+    return MyFieldSet{N}(geometry, displacement)
+end
+
+# When constructing new element, one must pass now the field set:
+
+element = Element(Quad4, MyFieldSet, (1, 2, 3, 4))
+
+@test has_sfield(element, :geometry) == true
+
+X = ([0.0,0.0], [1.0,0.0], [1.0,1.0], [0.0,1.0])
+u0 = ([0.0,0.0], [0.0,0.0], [0.0,0.0], [0.0,0.0])
+u1 = ([0.0,0.0], [0.0,0.0], [1.0,0.0], [0.0,0.0])
+
+# Indeed using sfield does not mean that they cannot be changed. The only
+# difference is that they cannot be created on the fly, thus there is no
+# `create_dfield!` at all. But `update_dfield!` works as expected.
+
+@test has_sfield(element, :geometry) == true
+
+update_sfield!(element, :geometry, X)
+update_sfield!(element, :displacement, 0.0 => u0)
+update_sfield!(element, :displacement, 1.0 => u1)
+
+# Interpolating fields etc. works as expected:
+
+um = interpolate_sfield(element, :displacement, 0.5)
+@test um[3] == [0.5, 0.0]
 
 ### Common routines to dfields and sfields
+
 
 using FEMBase: has_field, get_field, update_field!, interpolate_field
 
@@ -55,10 +103,24 @@ using FEMBase: has_field, get_field, update_field!, interpolate_field
 # as they outperform dynamically defined ones in access time, but then e.g.
 # if field is not statically defined, `update_field!` is creating a new dfield.
 
-@test has_field(element, :geometry) == true
-@test get_field(element, :youngs_modulus) === get_dfield(element, :youngs_modulus)
+element = Element(Quad4, MyFieldSet, (1, 2, 3, 4))
+
+update_field!(element, :geometry, X)
+update_field!(element, :displacement, 0.0 => u0)
+update_field!(element, :youngs_modulus, 288.0)
 update_field!(element, :poissons_ratio, 1/3)
+
+# For example, geometry and displacement are here sfields because they are
+# predefined using fieldset, but youngs modulus is dfield and created on-the-fly:
+
+@test has_field(element, :geometry) == true
+@test has_dfield(element, :geometry) == false
+@test has_sfield(element, :geometry) == true
+@test has_dfield(element, :youngs_modulus) == true
+@test has_sfield(element, :youngs_modulus) == false
+@test get_field(element, :youngs_modulus) === get_dfield(element, :youngs_modulus)
 @test interpolate_field(element, :poissons_ratio, 0.0) == 1/3
+@test interpolate_field(element, :geometry, 0.0) == X
 
 ### Creating and updating DVTI and DVTV fields using dictionaries
 
@@ -79,3 +141,27 @@ update!(element, :temperature, 1.0 => T)
 # update only that data to element.
 
 @test interpolate(element, :temperature, 1.0) == (T[1], T[2])
+
+### Performance difference between fields
+
+# The reason, like explained, for having two kinds of fields comes from the
+# performance. We need certain fields, like geometry, displacement, connectivity
+# and so on, work with maximum performance, because they are accessed all the
+# time. To make a short timing, we create geometry and geometry2, where the
+# first one is statically defined and latter one dynamically.
+
+#=
+X = ([0.0,0.0], [1.0,0.0], [1.0,1.0], [0.0,1.0])
+element = Element(Quad4, MyFieldSet, (1, 2, 3, 4))
+update!(element, :geometry, X)
+update!(element, :geometry2, X)
+using BenchmarkTools
+@btime interpolate($element, :geometry, 0.0)
+@btime interpolate($element, :geometry2, 0.0)
+=#
+
+# The following code will give in first case 1.466 ns and 0 memory allocations,
+# where the latter case is 37.755 ns with 1 memory allocation:
+#
+#  1.466 ns (0 allocations: 0 bytes)
+#  37.755 ns (1 allocation: 16 bytes)

--- a/test/test_problems.jl
+++ b/test/test_problems.jl
@@ -138,8 +138,8 @@ end
 
 function assemble_elements!(problem::Problem{P1},
                             assembly::Assembly,
-                            elements::Vector{Element{E}},
-                            time::Float64) where E
+                            elements::Vector{Element{M,E}},
+                            time::Float64) where {M,E}
 
     @debug "assemble_elements!" eltype=E
     bi = BasisInfo(E)
@@ -192,8 +192,8 @@ end
 
 function assemble_elements!(problem::Problem{DirBC},
                             assembly::Assembly,
-                            elements::Vector{Element{E}},
-                            time::Float64) where E
+                            elements::Vector{Element{M,E}},
+                            time::Float64) where {M,E}
 
     name = get_parent_field_name(problem)
     dim = get_unknown_field_dimension(problem)

--- a/test/test_problems.jl
+++ b/test/test_problems.jl
@@ -104,7 +104,7 @@ end
     as = get_assembly(p3)
     e1 = Element(Seg2, [1, 2])
     e2 = Element(Seg2, [2, 3])
-    e3 = Element(Seg2, Int[])
+    e3 = Element(Seg2, [0, 0])
     update!(e1, "f", [1.0, 1.0])
     update!(e2, "f", [2.0, 2.0])
     push!(p3, e1)
@@ -259,6 +259,4 @@ end
     @test get_gdofs(problem, element) == [1, 2, 3, 4]
     set_gdofs!(problem, element, [2, 3, 4, 5])
     @test get_gdofs(problem, element) == [2, 3, 4, 5]
-    element2 = Element(Seg2, Int[])
-    @test_throws ErrorException get_gdofs(problem, element2)
 end


### PR DESCRIPTION
This PR introduces a new type of set of fields, which must be defined and initialized when creating a new element. Closes issue #47. It is now well-known that the use of `Dict{String,AbstractField}`, where fields are dynamically defined during the simulation, leads to type instability problems. Problem is solved by having two kinds of fields in the element, let's call them `sfields` and `dfields`, where the `dfields` is the old implementation and `sfields` is the new one. 