### PR TITLE
Fix performance loss for consecutive runs

### DIFF
--- a/src/problems.jl
+++ b/src/problems.jl
@@ -57,6 +57,7 @@ function Assembly()
 end
 
 function empty!(assembly::Assembly)
+    empty!(assembly.M)
     empty!(assembly.K)
     empty!(assembly.Kg)
     empty!(assembly.f)
@@ -69,7 +70,8 @@ function empty!(assembly::Assembly)
 end
 
 function isempty(assembly::Assembly)
-    T = isempty(assembly.K)
+    T = isempty(assembly.M)
+    T &= isempty(assembly.K)
     T &= isempty(assembly.Kg)
     T &= isempty(assembly.f)
     T &= isempty(assembly.fg)


### PR DESCRIPTION
I had a huge perfomance loss when running an analysis multiple times. With each run the mem allocations went up. This was caused by the assembly of the global mass matrix, as it was never emptied and thus increased in each call to the assembly functions.